### PR TITLE
use libtool to create libraries.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,4 @@
 SUBDIRS = src examples tests
 EXTRA_DIST = Doxyfile README_cmake.txt win32
+
+ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,10 @@ AM_INIT_AUTOMAKE(foreign)
 AC_OUTPUT([Makefile src/Makefile examples/Makefile tests/Makefile])
 AC_CONFIG_SRCDIR([examples/binmode.c])
 AC_CONFIG_HEADER([config.h])
+AC_CONFIG_MACRO_DIRS([m4])
+
+# use libtool
+LT_INIT
 
 ## FROM: http://lists.gnu.org/archive/html/automake/2008-09/msg00075.html
 SX_CPPFLAGS="$CPPFLAGS -DNODEBUG"
@@ -24,7 +28,6 @@ AC_SUBST([SFSEXP_CFLAGS], $SX_CFLAGS)
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC
-AC_PROG_RANLIB
 
 # Checks for libraries.
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -4,7 +4,7 @@ LDFLAGS =
 
 noinst_PROGRAMS = binmode callbacks continuations packunpack paultest rcfile sexpvis simple_interp
 include_HEADERS = ../src/sexp.h
-LDADD = ../src/libsexp.a
+LDADD = ../src/libsexp.la
 binmode_SOURCES = binmode.c ../src/sexp.h
 callbacks_SOURCES = callbacks.c ../src/sexp.h
 continuations_SOURCES = continuations.c ../src/sexp.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ CFLAGS = $(SFSEXP_CFLAGS)
 CPPFLAGS = $(SFSEXP_CPPFLAGS)
 LDFLAGS =
 
-lib_LIBRARIES = libsexp.a
+lib_LTLIBRARIES = libsexp.la
 include_HEADERS = sexp.h sexp_vis.h sexp_ops.h sexp_memory.h sexp_errors.h cstring.h faststack.h
-libsexp_a_SOURCES = cstring.c cstring.h event_temp.c faststack.c faststack.h io.c parser.c sexp.c sexp.h sexp_memory.c sexp_memory.h sexp_errors.h sexp_ops.c sexp_ops.h sexp_vis.c sexp_vis.h
-
+libsexp_la_SOURCES = cstring.c cstring.h event_temp.c faststack.c faststack.h io.c parser.c sexp.c sexp.h sexp_memory.c sexp_memory.h sexp_errors.h sexp_ops.c sexp_ops.h sexp_vis.c sexp_vis.h
+libsexp_la_LDFLAGS = -version-info 1:0:0

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@ CPPFLAGS = -I../src $(SFSEXP_CPPFLAGS)
 LDFLAGS =
 
 noinst_PROGRAMS = ctest ctorture error_codes partial read_and_dump readtests
-LDADD = ../src/libsexp.a
+LDADD = ../src/libsexp.la
 ctest_SOURCES = ctest.c ../src/sexp.h
 ctorture_SOURCES = ctorture.c ../src/sexp.h
 error_codes_SOURCES = error_codes.c ../src/sexp.h


### PR DESCRIPTION
This allows relatively painless creation of shared libraries, which is
important for linux distros and similar uses.