### PR TITLE
make _sexp_to_dot static / hidden

### DIFF
--- a/src/sexp_vis.c
+++ b/src/sexp_vis.c
@@ -37,7 +37,7 @@ LA-CC-04-094
 #include "faststack.h"
 #include "sexp.h"
 
-void _sexp_to_dotfile(const sexp_t *sx, FILE *fp) {
+static void _sexp_to_dotfile(const sexp_t *sx, FILE *fp) {
   const sexp_t *tmp;
 
   tmp = sx;


### PR DESCRIPTION
It is not in the corresponding header file, so presumably not meant to
be extern.

I saw this in the list of exported symbols calculated by dpkg-gensymbols. If any of the following are also private, let me know and I will investigate 

 bfs_find_sexp@Base 1.3.1
 copy_sexp@Base 1.3.1
 cparse_sexp@Base 1.3.1
 destroy_continuation@Base 1.3.1
 destroy_iowrap@Base 1.3.1
 destroy_sexp@Base 1.3.1
 destroy_stack@Base 1.3.1
 eparse_sexp@Base 1.3.1
 find_sexp@Base 1.3.1
 init_continuation@Base 1.3.1
 init_iowrap@Base 1.3.1
 iparse_sexp@Base 1.3.1
 make_stack@Base 1.3.1
 new_sexp_atom@Base 1.3.1
 new_sexp_binary_atom@Base 1.3.1
 new_sexp_list@Base 1.3.1
 parse_sexp@Base 1.3.1
 pd_allocate@Base 1.3.1
 pd_cache@Base 1.3.1
 pd_deallocate@Base 1.3.1
 pop@Base 1.3.1
 print_pcont@Base 1.3.1
 print_sexp@Base 1.3.1
 print_sexp_cstr@Base 1.3.1
 push@Base 1.3.1
 read_one_sexp@Base 1.3.1
 reset_sexp_errno@Base 1.3.1
 sadd@Base 1.3.1
 saddch@Base 1.3.1
 sdestroy@Base 1.3.1
 sempty@Base 1.3.1
 set_parser_buffer_params@Base 1.3.1
 sexp_cleanup@Base 1.3.1
 sexp_errno@Base 1.3.1
 sexp_list_length@Base 1.3.1
 sexp_t_allocate@Base 1.3.1
 sexp_t_cache@Base 1.3.1
 sexp_t_deallocate@Base 1.3.1
 sexp_to_dotfile@Base 1.3.1
 sgrowsize@Base 1.3.1
 snew@Base 1.3.1
 strim@Base 1.3.1
 toCharPtr@Base 1.3.1
