### PR TITLE
fix for sexp_to_dotfile looping on empty lists

### DIFF
--- a/src/sexp_vis.c
+++ b/src/sexp_vis.c
@@ -74,12 +74,12 @@ static void _sexp_to_dotfile(const sexp_t *sx, FILE *fp) {
                 (unsigned long)tmp,
                 (unsigned long)tmp->list);
 	_sexp_to_dotfile(tmp->list,fp);
-	if (tmp->next != NULL)
-	  fprintf(fp,"  sx%lu:next -> sx%lu:type;\n",
-                  (unsigned long)tmp,
-                  (unsigned long)tmp->next);
-	tmp = tmp->next;
       }
+      if (tmp->next != NULL)
+        fprintf(fp,"  sx%lu:next -> sx%lu:type;\n",
+                (unsigned long)tmp,
+                (unsigned long)tmp->next);
+      tmp = tmp->next;
     } else {
       if (tmp->aty == SEXP_BINARY)
 	fprintf(fp,"| binlength=%lu | <next> next\"];\n",

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -4,3 +4,5 @@ error_codes
 partial
 read_and_dump
 readtests
+vis_test
+out*.dot

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@ CPPFLAGS = -I../src $(SFSEXP_CPPFLAGS)
 LDFLAGS =
 EXTRA_DIST = test_expressions dotests.sh randsexp.pl
 
-noinst_PROGRAMS = bug ctest ctorture error_codes partial read_and_dump readtests
+noinst_PROGRAMS = bug ctest ctorture error_codes partial read_and_dump readtests vis_test
 LDADD = ../src/libsexp.la
 bug_SOURCES = bug.c ../src/sexp.h
 ctest_SOURCES = ctest.c ../src/sexp.h

--- a/tests/README
+++ b/tests/README
@@ -79,3 +79,16 @@ quoting, and other possible things are interpreted by the parser correctly.
 Users are strongly encouraged to submit expressions that break the parser so
 that the bugs can be fixed and the rogue strings can be added to the
 test_expressions file to ensure that they don't break the parser in the future.
+
+To use vis_test.c :
+-------------------
+
+Add any desired s-expressions to the file 'test_expressions'. Run
+vis_test; if all s-expressions are sucessfully transformed to DOT, it
+will exit 0. DOT output can be examined in out${n}.dot where is the
+index (from 0) of the s-expression in 'test_expressions'. The optional
+first argument defines a number of seconds to allow the program to run
+before interrupting. Pass "0" to disable the watchdog timer (i.e. do
+not interrupt).
+
+

--- a/tests/vis_test.c
+++ b/tests/vis_test.c
@@ -1,0 +1,87 @@
+/**
+
+SFSEXP: Small, Fast S-Expression Library version 1.3
+Written by Matthew Sottile (mjsottile@gmail.com)
+
+Copyright (2003-2006). The Regents of the University of California. This
+material was produced under U.S. Government contract W-7405-ENG-36 for Los
+Alamos National Laboratory, which is operated by the University of
+California for the U.S. Department of Energy. The U.S. Government has rights
+to use, reproduce, and distribute this software. NEITHER THE GOVERNMENT NOR
+THE UNIVERSITY MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY
+LIABILITY FOR THE USE OF THIS SOFTWARE. If software is modified to produce
+derivative works, such modified software should be clearly marked, so as not
+to confuse it with the version available from LANL.
+
+Additionally, this library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of the
+License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this library; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, U SA
+
+LA-CC-04-094
+
+**/
+
+#ifndef WIN32
+# include <unistd.h>
+#else
+# define ssize_t int
+# include <io.h>
+# include <sys/types.h>
+#endif
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+#include "sexp.h"
+#include "sexp_vis.h"
+
+/**
+ * read file "test_expressions", write DOT representation of the n'th s-expression 
+ * as "out<n>.dot".
+ */
+int main(int argc, char **argv) {
+  sexp_t *a;
+  int fd;
+  sexp_iowrap_t *iow;
+  int count = 0;
+  unsigned int timeout = 1;
+
+  if (argc>1)
+    timeout = atoi (argv[1]);
+
+  /* Watchdog timer, to catch infinite loops */
+  alarm(timeout);
+  
+  fd = open("test_expressions",O_RDONLY);
+
+  iow = init_iowrap(fd);
+
+  a = read_one_sexp(iow);
+
+  while (a != NULL) {
+    char fname[4096];
+    sprintf (fname, "out%02d.dot", count++);
+    sexp_to_dotfile(a,fname);
+
+    destroy_sexp(a);
+    a = read_one_sexp(iow);
+  }
+
+  destroy_iowrap(iow);
+  sexp_cleanup();
+  close(fd);
+
+  exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
I decided to try using sexpvis to understand the structure of my examples, but they all had embedded empty lists in them, which caused sexp_to_dotfile to loop infinitely. This is my attempt at fixing things. The output  looks reasonable to me now, but given that I started from not understanding how the data structure should look, you should probably verify my fix :smile_cat:.

I'm not sure how portable "alarm" is to Windows. I do like not relying on the user to interrupt the test, since it can fill up a disk pretty quickly. If you think it's important I can look at the portability issue.