### PR TITLE
Install sfsexp.pc file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,7 @@
 SUBDIRS = src examples tests
 EXTRA_DIST = Doxyfile README.md README_cmake.txt win32
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = sfsexp.pc
+
 ACLOCAL_AMFLAGS = -I m4


### PR DESCRIPTION
sfsexp.pc is generated in configure script, however it is not installed under PREFIX.
Please install sfsexp.pc under libdir/pkgconfig to get flags with pkg-config command by dependent programs.