### PR TITLE
Honor LDFLAGS to fix RELRO build, for example

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,5 @@
 CFLAGS = $(SFSEXP_CFLAGS)
 CPPFLAGS = $(SFSEXP_CPPFLAGS)
-LDFLAGS =
 
 lib_LTLIBRARIES = libsexp.la
 include_HEADERS = sexp.h sexp_vis.h sexp_ops.h sexp_memory.h sexp_errors.h cstring.h faststack.h


### PR DESCRIPTION
I added '-Wl,-zrelro -Wl,-znow' to LDFLAGS for RELRO build.
However src/Makefile sets LDFLAGS as empty and the resulting binary is not build with RELRO support.
Please honor custom LDFLAGS for additional flags.