### PR TITLE
Rename sexpr to sfsexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ consolidated header that encapsulates all of the headers currently
 included in the library.  If you do not want to aim your project that
 uses the library into the library source and build directories
 directly, creating a separate installation prefix and installing there
-is recommended.  For example, from the root of the sexpr tree:
+is recommended.  For example, from the root of the sfsexp tree:
 
 ```
 % mkdir installTree

--- a/README_cmake.txt
+++ b/README_cmake.txt
@@ -1,17 +1,17 @@
-Using sexpr library from cmake-based projects:
+Using sfsexp library from cmake-based projects:
 ----------------------------------------------
 
-Presently, the library does not come with a proper FindSexpr.cmake module
+Presently, the library does not come with a proper FindSfsexp.cmake module
 file.  In the meantime, you can add the following lines to a CMakeLists.txt
-file.  Assuming the source tree for the sexpr library exists in
-/Users/matt/Research/sexpr/src  :
+file.  Assuming the source tree for the sfsexp library exists in
+/Users/matt/Research/sfsexp/src  :
 
 INCLUDE_DIRECTORIES(
-  /Users/matt/Research/sexpr/src/src
+  /Users/matt/Research/sfsexp/src/src
 )
 
 LINK_DIRECTORIES(
-  /Users/matt/Research/sexpr/src/src
+  /Users/matt/Research/sfsexp/src/src
 )
 
 And then just add "sexp" to the TARGET_LINK_LIBRARIES list.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT(sexpr, 1.3.1, mjsottile@me.com)
+AC_INIT(sfsexp, 1.3.1, mjsottile@me.com)
 AM_INIT_AUTOMAKE(foreign)
 AC_OUTPUT([Makefile src/Makefile examples/Makefile tests/Makefile])
 AC_CONFIG_SRCDIR([examples/binmode.c])


### PR DESCRIPTION
The name sexpr exists mostly for hysterical reasons. Rename sexpr to
sfsexp where it names the project: in the README files and in
`configure.ac` In particular, `make dist-gzip` and the like will
generate realease tarballs `sfsexp-$VERSION.$SUFFIX` (with top level
directory `sfsexp-$VERSION`), in accordance with the project name and
the GitHub generated tarballs.

sexpr is left in old code as well where it denotes an actual
s-expression.

closes #14