### PR TITLE
Pkgincludedir

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -4,7 +4,7 @@ LDFLAGS =
 EXTRA_DIST = testrc vis.in sexps.in edgelist.dat conttest
 
 noinst_PROGRAMS = binmode callbacks continuations packunpack paultest rcfile sexpvis simple_interp
-include_HEADERS = ../src/sexp.h
+noinst_HEADERS = ../src/sexp.h
 LDADD = ../src/libsexp.la
 binmode_SOURCES = binmode.c ../src/sexp.h
 callbacks_SOURCES = callbacks.c ../src/sexp.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,6 @@ CFLAGS = $(SFSEXP_CFLAGS)
 CPPFLAGS = $(SFSEXP_CPPFLAGS)
 
 lib_LTLIBRARIES = libsexp.la
-include_HEADERS = sexp.h sexp_vis.h sexp_ops.h sexp_memory.h sexp_errors.h cstring.h faststack.h
+pkginclude_HEADERS = sexp.h sexp_vis.h sexp_ops.h sexp_memory.h sexp_errors.h cstring.h faststack.h
 libsexp_la_SOURCES = cstring.c cstring.h event_temp.c faststack.c faststack.h io.c parser.c sexp.c sexp.h sexp_memory.c sexp_memory.h sexp_errors.h sexp_ops.c sexp_ops.h sexp_vis.c sexp_vis.h
 libsexp_la_LDFLAGS = -version-info 1:0:0


### PR DESCRIPTION
This change should make the packaging experience more uniform.

Besides testing locally, I've built Fedora (test) packages of notmuch against sfsexp with the changes from this PR. This exercises builds and tests (both `tests/dotests.sh` for sfsexp and the extensive notmuch test suite covering sfsexp usage), so I'm pretty confident about these changes ;-)

There is one scenario in which users of sfsexp may notice a change: If you didn't use pkgconfig and relied on sfsexp being on the unmodified standard include path you will have to adjust your `CFLAGS`. But this brings sfsexp more in line with other libraries. In addition, it would make Debian's sfsexp packager @bremner happy, too!