### PR TITLE
include LICENSE_LGPL in the distribution archive

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = src examples tests
-EXTRA_DIST = Doxyfile README.md README_cmake.txt win32
+EXTRA_DIST = Doxyfile LICENSE_LGPL README.md README_cmake.txt win32
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = sfsexp.pc


### PR DESCRIPTION
LGPL requires to ship a copy of the license, and COPYING rightly says
just that. So, ship LICENSE_LGPL (which is in the repo already) in the
distribution archives, as well.