### PR TITLE
few fixes to run test_builds.sh

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,4 @@
+To build, you'll need: autoconf automake libtool m4.
 
 To try things out, just type:
 

--- a/examples/check_leaks.sh
+++ b/examples/check_leaks.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test {
-    valgrind --leak-check=full --show-reachable=yes -q "$@" > /dev/null
+    libtool --mode=execute valgrind --leak-check=full --show-reachable=yes -q "$@" > /dev/null
     status=$?
     if [ $status -ne 0 ]; then
         echo "error with $1"
     else
-	echo "no error with $1"
+        echo "no error with $1"
     fi
     return $status
 }
@@ -19,4 +19,3 @@ test ./paultest
 test ./rcfile
 test ./sexpvis
 test ./simple_interp
-

--- a/python/test.py
+++ b/python/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import socket

--- a/test_builds.sh
+++ b/test_builds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -f ./configure ]; then
   echo "Generate configure first.  See INSTALL."

--- a/tests/check_leaks.sh
+++ b/tests/check_leaks.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test {
-    valgrind --leak-check=full --show-reachable=yes -q "$@" > /dev/null
+    libtool --mode=execute valgrind --leak-check=full --show-reachable=yes -q "$@" > /dev/null
     status=$?
     if [ $status -ne 0 ]; then
         echo "error with $1"
     else
-	echo "no error with $1"
+        echo "no error with $1"
     fi
     return $status
 }
@@ -14,7 +14,7 @@ function test {
 test ./ctest
 
 ## note: need to keep iteration count for ctorture low here
-## due to performance overhead of valgrind.  
+## due to performance overhead of valgrind.
 perl ./randsexp.pl 200 40000 0.4 > /tmp/SEXP.SKINNY
 test ./ctorture -i 10 -f /tmp/SEXP.SKINNY
 rm -f /tmp/SEXP.SKINNY


### PR DESCRIPTION
Ideally, the shebangs shouldn't be hardcoded since users might not have the program available there, hence rely on `/usr/bin/env` (that will also pick the preferred version, useful in the case of Python virtual envs for example (I did not test the Python bindings)).

Also fix the test invocation so libtool executes valgrind on the compiled test and not the wrapper script to avoid a bunch of unrelated errors.

PS: `examples/binmode` is missing its `testdata` and it doesn't look like it was ever checked in.