### PR TITLE
enable _NO_MEMORY_MANAGEMENT_ by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ Currently, the major features that can be enabled via autoconf are:
 - "--enable-thread-unsafe-memory-management" to enable caching of
   s-expressions in a thread-unsafe way.
 
-Other features are toggled by setting appropriate options in the CFLAGS:
+Other features are toggled by setting appropriate options in the CFLAGS,
+such as the memory-limiting mode.
 
 ```
-% CFLAGS=-D__DISABLE_MEMMAN__ ./configure
+% CFLAGS=-D_SEXP_LIMIT_MEMORY_ ./configure
 ```
+
 Note that you should use the vanilla configuration unless you know that you
 want to use debug mode or other options, and understand precisely what they
 mean.

--- a/README.md
+++ b/README.md
@@ -44,14 +44,16 @@ Configure the sources via autoconf.
 % ./configure
 ```
 
-Currently, the only feature that can be enabled via autoconf is to
-enable any debugging code in the library by specifying
-"--enable-debug".  Other features such as disabling memory management
-by the library are toggled by setting appropriate options in the
-CFLAGS:
+Currently, the major features that can be enabled via autoconf are:
+
+- "--enable-debug" to enable any debugging code in the library,
+- "--enable-thread-unsafe-memory-management" to enable caching of
+  s-expressions in a thread-unsafe way.
+
+Other features are toggled by setting appropriate options in the CFLAGS:
 
 ```
-% CFLAGS=-D_NO_MEMORY_MANAGEMENT_ ./configure
+% CFLAGS=-D__DISABLE_MEMMAN__ ./configure
 ```
 Note that you should use the vanilla configuration unless you know that you
 want to use debug mode or other options, and understand precisely what they
@@ -139,7 +141,7 @@ incomplete and needs more data to complete it."
 are reading data encoded as sexps. For example, it's not uncommon for
 a big hunk o' data to be encoded as a single sexp in a file. One way
 to handle this situation is to get the file size, dynamically allocate
-a buffer big enought to hold it, and then use `parse_sexp`. Here's a
+a buffer big enough to hold it, and then use `parse_sexp`. Here's a
 minimal example (error checking omitted):
 
 ```c

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,11 @@ AC_ARG_ENABLE(debug,
    [AS_HELP_STRING([--enable-debug],[turn on debug options and code (disabled by default)])],
    [SX_CPPFLAGS="" SX_CFLAGS="$CFLAGS -g -O0 -Wall"],
    [])
- 
+
+AC_ARG_ENABLE(thread-unsafe-memory-management,
+   [AS_HELP_STRING([--enable-thread-unsafe-memory-management],[turn on thread-unsafe memory management (disabled by default)])],
+   [],
+   [SX_CFLAGS="$SX_CFLAGS -D_NO_MEMORY_MANAGEMENT_"])
 
 # Export flags
 AC_SUBST([SFSEXP_CPPFLAGS], $SX_CPPFLAGS)

--- a/test_builds.sh
+++ b/test_builds.sh
@@ -9,6 +9,24 @@ if [ -f ./Makefile ]; then
   make distclean
 fi
 
+./configure --enable-thread-unsafe-memory-management
+make
+cd tests
+./check_leaks.sh
+cd ../examples
+./check_leaks.sh
+cd ..
+
+make distclean
+./configure --enable-debug --enable-thread-unsafe-memory-management
+make
+cd tests
+./check_leaks.sh
+cd ../examples
+./check_leaks.sh
+cd ..
+
+make distclean
 ./configure
 make
 cd tests
@@ -19,24 +37,6 @@ cd ..
 
 make distclean
 ./configure --enable-debug
-make
-cd tests
-./check_leaks.sh
-cd ../examples
-./check_leaks.sh
-cd ..
-
-make distclean
-CFLAGS=-D_NO_MEMORY_MANAGEMENT_ ./configure
-make
-cd tests
-./check_leaks.sh
-cd ../examples
-./check_leaks.sh
-cd ..
-
-make distclean
-CFLAGS=-D_NO_MEMORY_MANAGEMENT_ ./configure --enable-debug 
 make
 cd tests
 ./check_leaks.sh


### PR DESCRIPTION
See #21 for context.

Not sure if you want to keep `CFLAGS=-D__DISABLE_MEMMAN__ ./configure` as an example, that appears to be the only define left but it's limited to an example.